### PR TITLE
[PR-2] Fixed viper flag binding for the --verbose flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.arcane-game-server.yaml)")
+
 	rootCmd.Flags().BoolP("verbose", "v", false, "Enable additional verbosity in logging")
+	viper.BindPFlag("verbose", runCmd.Flags().Lookup("verbose"))
 }
 
 func initConfig() {


### PR DESCRIPTION
The verbose value declared in the config file was not bound to the Cobra PFlag